### PR TITLE
Change default implementation for removeAll

### DIFF
--- a/Source/Core/Collection/ModelCollection.swift
+++ b/Source/Core/Collection/ModelCollection.swift
@@ -193,6 +193,25 @@ public extension ModelCollection {
 
     // MARK: Delete
 
+    /// Removes all elements from the collection.
+    ///
+    /// Calling this method may invalidate any existing indices for use with this
+    /// collection.
+    ///
+    /// - Parameter keepCapacity: Pass `true` to request that the collection
+    ///   avoid releasing its storage. Retaining the collection's storage can
+    ///   be a useful optimization when you're planning to grow the collection
+    ///   again. The default value is `true`.
+    ///
+    /// - Complexity: O(*n*), where *n* is the length of the collection.
+    mutating func removeAll(keepingCapacity keepCapacity: Bool = true) {
+        if !keepCapacity {
+            self = .init()
+        } else {
+            self.removeSubrange(startIndex..<endIndex)
+        }
+    }
+
     /// Removes all elements from the section.
     ///
     /// Calling this method may invalidate any existing indices for use with this

--- a/Source/Core/DataSource/CollectionViewDataSource.swift
+++ b/Source/Core/DataSource/CollectionViewDataSource.swift
@@ -15,6 +15,12 @@ open class CollectionViewDataSource: NSObject {
         buffer = []
         super.init()
     }
+
+    /// The total number of elements that the collection can contain without
+    /// allocating new storage.
+    public var capacity: Int {
+        return buffer.capacity
+    }
 }
 
 // MARK: - ModelCollection conformance (MutableCollection, RandomAccessCollection, RangeReplaceableCollection)

--- a/Source/Core/DataSource/TableViewDataSource.swift
+++ b/Source/Core/DataSource/TableViewDataSource.swift
@@ -15,6 +15,12 @@ open class TableViewDataSource: NSObject {
         buffer = []
         super.init()
     }
+
+    /// The total number of elements that the collection can contain without
+    /// allocating new storage.
+    public var capacity: Int {
+        return buffer.capacity
+    }
 }
 
 // MARK: - ModelCollection Collection conformance (MutableCollection, RandomAccessCollection, RangeReplaceableCollection)

--- a/Tests/ModelCollectionTests.swift
+++ b/Tests/ModelCollectionTests.swift
@@ -128,6 +128,16 @@ final class ModelCollectionTests: XCTestCase {
         tableViewTesting.testRemoveDecorative()
         collectionViewTesting.testRemoveDecorative()
     }
+
+    func testRemoveAllKeepingCapacity() {
+        tableViewTesting.testRemoveAllKeepingCapacity()
+        collectionViewTesting.testRemoveAllKeepingCapacity()
+    }
+
+    func testRemoveAllNotKeeingCapacity() {
+        tableViewTesting.testRemoveAllNotKeeingCapacity()
+        collectionViewTesting.testRemoveAllNotKeeingCapacity()
+    }
 }
 
 // MARK: Helper
@@ -585,5 +595,34 @@ private class ModelCollectionTesting<C: ModelCollection> {
 
         collection.remove(decorative: decorativeKind, inSection: sectionIndex)
         XCTAssertNil(collection[sectionIndex, decorativeKind], "\(collectionName) failed to remove decorative")
+    }
+
+    func testRemoveAllKeepingCapacity() {
+        guard let item = createItem?("item") else {
+            return XCTFail("\(collectionName) failed to create items")
+        }
+
+        var collection: C = .init(repeatElement(.init(decoratives: [:], items: [item]), count: 10))
+        XCTAssertFalse(collection.isEmpty)
+
+        let addressBefore: UnsafeMutableRawPointer =  Unmanaged.passUnretained(collection as AnyObject).toOpaque()
+        collection.removeAll() // Default should be keepingCapacity = true
+        let addressAfter: UnsafeMutableRawPointer = Unmanaged.passUnretained(collection as AnyObject).toOpaque()
+        XCTAssertEqual(addressBefore, addressAfter)
+    }
+
+
+    func testRemoveAllNotKeeingCapacity() {
+        guard let item = createItem?("item") else {
+            return XCTFail("\(collectionName) failed to create items")
+        }
+
+        var collection: C = .init(repeatElement(.init(decoratives: [:], items: [item]), count: 10))
+        XCTAssertFalse(collection.isEmpty)
+
+        let addressBefore: UnsafeMutableRawPointer =  Unmanaged.passUnretained(collection as AnyObject).toOpaque()
+        collection.removeAll(keepingCapacity: false)
+        let addressAfter: UnsafeMutableRawPointer = Unmanaged.passUnretained(collection as AnyObject).toOpaque()
+        XCTAssertNotEqual(addressBefore, addressAfter)
     }
 }


### PR DESCRIPTION
Changes the default value of keepCapacity in removeAll() to true, which matches the typical use case of a datasource. References to the datasource will stay the same, which simplifies cleaning up a datasource before refilling it (Resetting the UITableView's datasource is not necessary anymore).