### PR TITLE
Feature/fix for xcode13.3

### DIFF
--- a/CellularModelDataSource.podspec
+++ b/CellularModelDataSource.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |spec|
  spec.name             = 'CellularModelDataSource'
  spec.swift_version    = '5.1'
  spec.module_name      = 'ModelDataSource'
- spec.version          = '6.0.0'
+ spec.version          = '6.1.0'
  spec.summary          = 'Easy TableView and CollectionView data handling.'
 
 # This description is used to generate tags and improve search results.

--- a/Sources/ModelDataSource/UIKit/CollectionView+ModelDataSourceView.swift
+++ b/Sources/ModelDataSource/UIKit/CollectionView+ModelDataSourceView.swift
@@ -81,9 +81,10 @@ extension UICollectionView: ModelDataSourceView {
 // MARK: - ModelDataSourceViewDisplayable
 
 /// We need to add a typealias for each class that implements ModelDataSourceViewDisplayable
-/// to make Xcode13.3 / Swift 5.6 happy. Otherwise we have would have to implement
+/// to make Xcode13.3 / Swift 5.6 happy. Otherwise we would have to implement
 /// public static var staticSize: Size for every class separatelly.
 /// https://stackoverflow.com/questions/71563154/how-to-implement-static-variables-of-associated-types-in-protocol-extensions-in
+
 extension UICollectionView {
     public typealias Size = CGSize
 }
@@ -91,7 +92,6 @@ extension UICollectionView {
 extension UICollectionReusableView {
     public typealias Size = CGSize
 }
-
 
 extension ModelDataSourceViewDisplayable where Self: UICollectionView {
 

--- a/Sources/ModelDataSource/UIKit/CollectionView+ModelDataSourceView.swift
+++ b/Sources/ModelDataSource/UIKit/CollectionView+ModelDataSourceView.swift
@@ -80,10 +80,23 @@ extension UICollectionView: ModelDataSourceView {
 
 // MARK: - ModelDataSourceViewDisplayable
 
+/// We need to add a typealias for each class that implements ModelDataSourceViewDisplayable
+/// to make Xcode13.3 / Swift 5.6 happy. Otherwise we have would have to implement
+/// public static var staticSize: Size for every class separatelly.
+/// https://stackoverflow.com/questions/71563154/how-to-implement-static-variables-of-associated-types-in-protocol-extensions-in
+extension UICollectionView {
+    public typealias Size = CGSize
+}
+
+extension UICollectionReusableView {
+    public typealias Size = CGSize
+}
+
+
 extension ModelDataSourceViewDisplayable where Self: UICollectionView {
 
     /// Optional fixed size definition to override dynamic height calculations.
-    public static var staticSize: CGSize? {
+    public static var staticSize: Size? {
         return nil
     }
 }
@@ -91,7 +104,7 @@ extension ModelDataSourceViewDisplayable where Self: UICollectionView {
 extension ModelDataSourceViewDisplayable where Self: UICollectionReusableView {
 
     /// Optional fixed size definition to override dynamic height calculations.
-    public static var staticSize: CGSize? {
+    public static var staticSize: Size? {
         return nil
     }
 }

--- a/Sources/ModelDataSource/UIKit/CollectionView+ModelDataSourceView.swift
+++ b/Sources/ModelDataSource/UIKit/CollectionView+ModelDataSourceView.swift
@@ -85,7 +85,7 @@ extension UICollectionView: ModelDataSourceView {
 /// public static var staticSize: Size for every class separatelly.
 /// https://stackoverflow.com/questions/71563154/how-to-implement-static-variables-of-associated-types-in-protocol-extensions-in
 
-extension UICollectionView {
+extension UICollectionViewCell {
     public typealias Size = CGSize
 }
 
@@ -93,7 +93,7 @@ extension UICollectionReusableView {
     public typealias Size = CGSize
 }
 
-extension ModelDataSourceViewDisplayable where Self: UICollectionView {
+extension ModelDataSourceViewDisplayable where Self: UICollectionViewCell {
 
     /// Optional fixed size definition to override dynamic height calculations.
     public static var staticSize: Size? {

--- a/Sources/ModelDataSource/UIKit/TableView+ModelDataSourceView.swift
+++ b/Sources/ModelDataSource/UIKit/TableView+ModelDataSourceView.swift
@@ -49,10 +49,23 @@ extension UITableView: ModelDataSourceView {
 
 // MARK: - ModelDataSourceViewDisplayable
 
+/// We need to add a typealias for each class that implements ModelDataSourceViewDisplayable
+/// to make Xcode13.3 / Swift 5.6 happy. Otherwise we have would have to implement
+/// public static var staticSize: Size for every class separatelly.
+/// https://stackoverflow.com/questions/71563154/how-to-implement-static-variables-of-associated-types-in-protocol-extensions-in
+extension UITableViewCell {
+    public typealias Size = CGFloat
+}
+
+extension UITableViewHeaderFooterView {
+    public typealias Size = CGFloat
+}
+
+
 extension ModelDataSourceViewDisplayable where Self: UITableViewCell {
 
     /// Optional fixed size definition to override dynamic height calculations.
-    public static var staticSize: CGFloat? {
+    public static var staticSize: Size? {
         return nil
     }
 }
@@ -60,7 +73,7 @@ extension ModelDataSourceViewDisplayable where Self: UITableViewCell {
 extension ModelDataSourceViewDisplayable where Self: UITableViewHeaderFooterView {
 
     /// Optional fixed size definition to override dynamic height calculations.
-    public static var staticSize: CGFloat? {
+    public static var staticSize: Size? {
         return nil
     }
 }

--- a/Sources/ModelDataSource/UIKit/TableView+ModelDataSourceView.swift
+++ b/Sources/ModelDataSource/UIKit/TableView+ModelDataSourceView.swift
@@ -50,9 +50,10 @@ extension UITableView: ModelDataSourceView {
 // MARK: - ModelDataSourceViewDisplayable
 
 /// We need to add a typealias for each class that implements ModelDataSourceViewDisplayable
-/// to make Xcode13.3 / Swift 5.6 happy. Otherwise we have would have to implement
+/// to make Xcode13.3 / Swift 5.6 happy. Otherwise we would have to implement
 /// public static var staticSize: Size for every class separatelly.
 /// https://stackoverflow.com/questions/71563154/how-to-implement-static-variables-of-associated-types-in-protocol-extensions-in
+
 extension UITableViewCell {
     public typealias Size = CGFloat
 }
@@ -60,7 +61,6 @@ extension UITableViewCell {
 extension UITableViewHeaderFooterView {
     public typealias Size = CGFloat
 }
-
 
 extension ModelDataSourceViewDisplayable where Self: UITableViewCell {
 


### PR DESCRIPTION
This should fix the issue that came with Xcode13.3 / Swift 5.6 that we would have to add the static property staticSize to every class that implements ModelDataSourceViewDisplyable. Otherwise the implementation of the protocol is incomplete.

See
https://stackoverflow.com/questions/71563154/how-to-implement-static-variables-of-associated-types-in-protocol-extensions-in